### PR TITLE
fix: cleanup code for multiple instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: preprocess build
+all: preprocess fmt build
 
 preprocess:
 	curl -OL https://raw.githubusercontent.com/joscha82/wattpilot/da08c3fb387b06497e007bef1ff88f0112a080ea/src/wattpilot/ressources/wattpilot.yaml
@@ -8,6 +8,8 @@ preprocess:
 	cat wattpilot.yaml | yq e '.properties[] | select( .key != "pvopt_deltaA" and .key != "pvopt_deltaP")  |  ( "\"" + .alias  + "\":\"" + .key + "\",")' >> wattpilot_mapping_gen.go
 	echo "}" >> wattpilot_mapping_gen.go
 
+fmt:
+	go fmt ./...
 
 build:
 	CURPWD=$(PWD)


### PR DESCRIPTION
fix: remove global variables
fix: use `go fmt` after generation lut