### PR TITLE
#33 prometheus exporter added missing metrics

### DIFF
--- a/prometheus/main.go
+++ b/prometheus/main.go
@@ -63,6 +63,17 @@ func newWattpilotCollector(charger *wattpilot.Wattpilot) *wattpilotCollector {
 			nil, constLabels,
 		)
 	}
+
+	for key := range wattpilot.PostProcess {
+		if metrics[key] != nil {
+			continue
+		}
+		metrics[key] = prometheus.NewDesc(
+			fmt.Sprintf(wattpilotPrefix, key),
+			fmt.Sprintf("Wattpilot property %s", key),
+			nil, constLabels,
+		)
+	}
 	return &wattpilotCollector{metrics: metrics, charger: charger}
 }
 
@@ -94,10 +105,12 @@ func (collector *wattpilotCollector) Collect(ch chan<- prometheus.Metric) {
 			if !data {
 				value = 0.0
 			}
+			break
 		default:
-			in_value := fmt.Sprintf("%v", value)
+			in_value := fmt.Sprintf("%v", data)
 			if out_value, err := strconv.ParseFloat(in_value, 64); err == nil {
 				value = out_value
+				break
 			}
 			continue
 		}

--- a/wattpilot.go
+++ b/wattpilot.go
@@ -495,7 +495,7 @@ func (w *Wattpilot) GetProperty(name string) (interface{}, error) {
 	if v, isKnown := propertyMap[name]; isKnown {
 		name = v
 	}
-	m, post := postProcess[origName]
+	m, post := PostProcess[origName]
 	if post {
 		name = m.key
 	}

--- a/wattpilot_mapping.go
+++ b/wattpilot_mapping.go
@@ -6,7 +6,7 @@ import (
 
 type PostFunction func(interface{}) (string, error)
 
-var postProcess = map[string]struct {
+var PostProcess = map[string]struct {
 	key string
 	f   PostFunction
 }{


### PR DESCRIPTION
Added missing metrics for `nrg` property. For this the PostProcess map was exported. Hence, new release of wattpilot is necessary and adaptation of version in prometheus exporter.

Additionally the collect function was fixed to parse the string returned by PostProcess to float.