### PR TITLE
Update wattpilot.go add reconnect 

### DIFF
--- a/wattpilot.go
+++ b/wattpilot.go
@@ -487,7 +487,14 @@ func (w *Wattpilot) GetProperty(name string) (interface{}, error) {
 	w._log.WithFields(log.Fields{"wattpilot": w._host}).Debug("Get Property ", name)
 
 	if !w._isInitialized {
-		return nil, errors.New("connection is not valid")
+		if !w._isConnected {
+			w.reconnect()
+			return nil, errors.New("connection is not valid and not initialized, tried reconnect")
+		}
+		 connection not initialized-> close
+		w._isInitialized = true
+		w.disconnectImpl() 
+		return nil, errors.New("connection is not valid, connected but not initialized, disconnected")
 	}
 
 	origName := name


### PR DESCRIPTION
Teilweise Lösung von #36
Macht auch einen Reconnect, wenn die Verbindung zu einem Wattpilot länger(ca. 5min) verloren geht. Ansonsten bleibt die Verbindung auf Status "No Hello there" stehen.
Ist aus meiner Sicht konzeptionell nicht sauber, da der Reconnect vermutlich im processLoop implementiert wurde. Da bin ich jedoch in go nicht fit genug.

